### PR TITLE
Fix setup instructions for Rails 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,8 @@ variables you can create the following static configuration:
 
 ```ruby
 # config/initializers/spree.rb
-
-Spree.config do |config|
-  # ...
-
-  config.static_model_preferences.add(
+Rails.application.config.to_prepare do
+  Spree::Config.static_model_preferences.add(
     Spree::PaymentMethod::StripeCreditCard,
     'stripe_env_credentials',
     secret_key: ENV['STRIPE_SECRET_KEY'],


### PR DESCRIPTION
> Summary
> 
> Since Rails 7, it's [no longer possible to reference a loadable constant](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-and-on-each-reload) on the initialize phase [1]. We need to wrap the setup within a to_prepare block, as it's already [documented in our guides](https://guides.solidus.io/advanced-solidus/model-preferences#static-preferences).

Credits to: @waiting-for-dev

Pretty much a copy of: https://github.com/solidusio/solidus_paypal_braintree/pull/332